### PR TITLE
refactor: update email retrieval method and enhance email model

### DIFF
--- a/api/graphql/resolver/threads_resolvers.go
+++ b/api/graphql/resolver/threads_resolvers.go
@@ -70,7 +70,7 @@ func (r *queryResolver) GetAllThreads(ctx context.Context, userID string, pagina
 		mappedThread := mappers.MapGormThreadToGraph(thread)
 		mappedThread.UserID = userID
 
-		email, err := r.repositories.EmailRepository.GetByID(ctx, thread.LastMessageID)
+		email, err := r.repositories.EmailRepository.GetByMessageID(ctx, thread.LastMessageID)
 		if err != nil {
 			tracing.TraceErr(span, err)
 			return nil, api_errors.NewError("unable to retrieve email", api_errors.CodeInternal, nil)

--- a/internal/models/email.go
+++ b/internal/models/email.go
@@ -32,6 +32,8 @@ type Email struct {
 	TrackClicks  bool           `gorm:"column:track_clicks;default:false" json:"trackClicks"`
 	IsViewed     bool           `gorm:"column:isViewed;default:false" json:"isViewed"`
 
+	Folder       string         `gorm:"column:folder;type:varchar(100);not null" json:"folder"`
+
 	// Content
 	Body          string `gorm:"column:body;type:text" json:"body"`
 	HasAttachment bool   `gorm:"column:has_attachment;default:false" json:"hasAttachment"`

--- a/services/imap/service.go
+++ b/services/imap/service.go
@@ -407,7 +407,7 @@ func (s *IMAPService) processSingleMailboxIteration(
 	span.LogFields(tracingLog.String("folders", fmt.Sprintf("%v", config.SyncFolders)))
 
 	// Process each folder sequentially
-	_, connectivityError := s.syncFolders(ctx, client, config.ID, config.SyncFolders)
+	_, connectivityError := s.syncFolders(ctx, client, mailboxID, config.SyncFolders)
 
 	// Handle connectivity errors
 	if connectivityError != nil {


### PR DESCRIPTION
- Changed the method for retrieving emails by message ID in the threads resolver.
- Added a new 'Folder' field to the Email model to support folder categorization.
- Updated the IMAP service to use mailbox ID instead of config ID for folder synchronization.