### PR TITLE
patch: set span name as tag

### DIFF
--- a/internal/telemetry/helpers.go
+++ b/internal/telemetry/helpers.go
@@ -99,6 +99,7 @@ func StartSpan(ctx context.Context, operationName string, opts ...SpanOptions) (
 	} else {
 		otelCtx, otelSpan = tracer.Start(ctx, operationName)
 	}
+	otelSpan.SetAttributes(attribute.String("name", operationName))
 
 	otelSpan.SetAttributes(
 		attribute.String("service.name", "mailstack"),


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Set span name as an attribute in OpenTelemetry spans in `helpers.go`.
> 
>   - **Telemetry Enhancement**:
>     - In `helpers.go`, `StartSpan()` now sets the span name as an attribute `name` in OpenTelemetry spans.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fmailstack&utm_source=github&utm_medium=referral)<sup> for db766f8925ae4a30f66af59f27fa1cf428ad54af. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->