### PR TITLE
patch: set span name as tag

### DIFF
--- a/internal/telemetry/helpers.go
+++ b/internal/telemetry/helpers.go
@@ -99,7 +99,7 @@ func StartSpan(ctx context.Context, operationName string, opts ...SpanOptions) (
 	} else {
 		otelCtx, otelSpan = tracer.Start(ctx, operationName)
 	}
-	otelSpan.SetAttributes(attribute.String("name", operationName))
+	otelSpan.SetAttributes(attribute.String("operation.name", operationName))
 
 	otelSpan.SetAttributes(
 		attribute.String("service.name", "mailstack"),


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Change span attribute key from `name` to `operation.name` in `StartSpan()` in `helpers.go`.
> 
>   - **Behavior**:
>     - In `StartSpan()` in `helpers.go`, change span attribute key from `name` to `operation.name` for OpenTelemetry spans.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Fmailstack&utm_source=github&utm_medium=referral)<sup> for da8d849e220508c2e29937915d85300e4015716b. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->